### PR TITLE
Improve WeaponMechanics compatibility

### DIFF
--- a/src/main/kotlin/net/pdevita/creeperheal2/compatibility/WeaponMechanics.kt
+++ b/src/main/kotlin/net/pdevita/creeperheal2/compatibility/WeaponMechanics.kt
@@ -7,6 +7,7 @@ import net.pdevita.creeperheal2.CreeperHeal2
 import org.bukkit.block.Block
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
+import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.plugin.Plugin
 
 @AutoService(BaseCompatibility::class)
@@ -36,5 +37,14 @@ class WeaponMechanics : BaseCompatibility {
         }
 
         creeperHeal2.createNewExplosion(allowedBlocks)
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onWeaponMechanicsBreakBlockEvent(event: BlockBreakEvent) {
+        if (event.eventName == "WeaponMechanicsBlockDamage") {
+            if (event.block.location.world?.let { creeperHeal2.settings.worldList.allowWorld(it.name) } == true) {
+                creeperHeal2.createNewExplosion(listOf(event.block))
+            }
+        }
     }
 }


### PR DESCRIPTION
Improve WeaponMechanics compatibility by creating an explosion object from blocks broken (not just blown up) by guns after repeated shots